### PR TITLE
use image from subpages (if not found on main page) for social cards

### DIFF
--- a/social-seo-metatags.php
+++ b/social-seo-metatags.php
@@ -198,6 +198,24 @@ class SocialSEOMetaTagsPlugin extends Plugin
     return $meta;
   }
 
+  // Searches in the page and in the children of that page (use case: modular pages).
+  private function getFirstImage() {
+      if (!empty($this->grav['page']->value('media.image'))) {
+          $images = $this->grav['page']->media()->images();
+      } elseif (!empty($this->grav['page']->collection())) {
+          foreach ($this->grav['page']->collection() as $child) {
+              if (!empty($child->value('media.image'))) {
+                  $images = $child->media()->images();
+                  break;
+              }
+          }
+      } else {
+          return null;
+      }
+
+    return array_shift($images);
+  }
+
   private function getTwitterCardMetatags($meta){
 
     if($this->grav['config']->get('plugins.social-seo-metatags.social_pages.pages.twitter.enabled')) {
@@ -221,10 +239,9 @@ class SocialSEOMetaTagsPlugin extends Plugin
       }
 
       if (!isset($meta['twitter:image'])) {
-        if (!empty($this->grav['page']->value('media.image'))) {
-          $images = $this->grav['page']->media()->images();
-          $image  = array_shift($images);
+        $image = $this->getFirstImage();
 
+        if (isset($image)) {
           $meta['twitter:image']['name']     = 'twitter:image';
           $meta['twitter:image']['property'] = 'twitter:image';
           $meta['twitter:image']['content']  = $this->grav['uri']->base() . $image->url();
@@ -286,10 +303,8 @@ class SocialSEOMetaTagsPlugin extends Plugin
         $meta['og:url']['content']          = $this->grav['uri']->url(true);
       }
 
-      if (!empty($this->grav['page']->value('media.image')) && !isset($meta['og:image'])) {
-        $images = $this->grav['page']->media()->images();
-        $image  = array_shift($images);
-
+      $image = $this->getFirstImage();
+      if (isset($image) && !isset($meta['og:image'])) {
         $meta['og:image']['property']  = 'og:image';
         $meta['og:image']['content']   = $this->grav['uri']->base() . $image->url();
       }

--- a/social-seo-metatags.php
+++ b/social-seo-metatags.php
@@ -146,7 +146,7 @@ class SocialSEOMetaTagsPlugin extends Plugin
           $keywords_tab = array_slice($keywords_tab, 0, $length);
           $keywords = join(',',$keywords_tab);
         }
-  
+
         if($keywords != "")
         {
           $meta['keywords']['name']      = 'keywords';
@@ -201,14 +201,17 @@ class SocialSEOMetaTagsPlugin extends Plugin
   // Searches in the page and in the children of that page (use case: modular pages).
   private function getFirstImage() {
       if (!empty($this->grav['page']->value('media.image'))) {
-          $images = $this->grav['page']->media()->images();
+        $images = $this->grav['page']->media()->images();
       } elseif (!empty($this->grav['page']->collection())) {
-          foreach ($this->grav['page']->collection() as $child) {
-              if (!empty($child->value('media.image'))) {
-                  $images = $child->media()->images();
-                  break;
-              }
+        foreach ($this->grav['page']->collection() as $child) {
+          if (!empty($child->value('media.image'))) {
+            $images = $child->media()->images();
+            break;
           }
+        }
+        if (!isset($image)) {
+          return null;
+        }
       } else {
           return null;
       }


### PR DESCRIPTION
Hey,

Thanks for this awesome plugin !

If you use modular pages, it's very likely that the image you want to use for your social cards (twitter, opengraph) is coming from the hero 😉

However he hero page is a child of the main page and your plugin doesn't search that far.

That's why I extended your work to search media images from children as well.

Hope you'll integrate that in the main version project !

Cheers