### PR TITLE
Fix issue #1: howto personalize description for a specific page ?

### DIFF
--- a/social-seo-metatags.php
+++ b/social-seo-metatags.php
@@ -98,7 +98,7 @@ class SocialSEOMetaTagsPlugin extends Plugin
       /**
        *  SEO Description
        **/
-      if(!isset($page_header->metadata->description)) {
+      if(!isset($page_header->metadata['description'])) {
         $meta['description']['name']      = 'description';
         $meta['description']['content']   = $this->desc;
       }


### PR DESCRIPTION
The fix for [issue #1: howto personalize description for a specific page ?](https://github.com/clemdesign/grav-plugin-social-seo-metatags/issues/1) applies the following test to check if a page contains frontmatter for description:
```
if(!isset($page_header->metadata->description)) {
    $meta['description']['name']      = 'description';
    $meta['description']['content']   = $this->desc;
}
```

Hower, the value of `$page_header->metadata` is an array and therefor, `!isset($page_header->metadata->description)` will always be true. Hence the user-defined frontmatter 'metadata:description' will still be ignored.

The test should be `!isset($page_header->metadata['description']`