### PR TITLE
Differentiate Open Graph and Facebook Insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
+# v2.0.0
+## 01/10/2019
+
+1. [](#new)
+    * Allow the use of Open Graph without Facebook Insights.
+
+
 # v1.2.0
 ## 02/06/2019
 
 1. [](#improved)
     * Treat request of Issue [#7](https://github.com/clemdesign/grav-plugin-social-seo-metatags/issues/7)
        > Improve set-up of description from frontmatter header page
-
 
 
 # v1.1.3

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Note: `keyword` meta-tag is deprecated for the most bots but this plugin allow m
 # Features
 
 * [Open Graph](http://ogp.me/) support.
+* [Facebook Insights](https://developers.facebook.com/docs/sharing/referral-insights) support.
 * [Twitter Cards](https://dev.twitter.com/cards/overview) support. You can select between Summary and Large cards.
 
 
@@ -43,8 +44,6 @@ This will clone this repository into the _social-seo-metatags_ folder.
 
 
 # Usage
-
-Plugin no need to edit any template :)
 
 After enabling plugin and options, 2 solutions:
   - Nothing to do: Items are determined from your page (Description, Keywords...)
@@ -142,14 +141,21 @@ social_pages:
 
 ### Namespace configuration
 
-Facebook uses [OpenGraph](http://ogp.me/) metatags that requires to use a namespace on `html` tag.
+Facebook uses [OpenGraph](http://ogp.me/) metatags. That requires to use a namespace on `html` tag.
 
 In your base template, add the following line in the `html` tag:
 
 ```twig
-<html {{
-  (config.plugins['social-seo-metatags'].enabled and config.plugins['social-seo-metatags'].social_pages.pages.facebook.enabled) ? 'xmlns:og="http://ogp.me/ns#"' : ''
-}}>
+<html
+    {{- (
+            config.plugins['social-seo-metatags'].enabled
+            and
+            config.plugins['social-seo-metatags'].social_pages.pages.opengraph.enabled
+        )
+        ? 'xmlns:og="http://ogp.me/ns#"'
+        : ''
+    -}}
+>
 ```
 
 ### Plugin configuration
@@ -158,14 +164,16 @@ For Facebook, you have the following default configuration:
 ```
 social_pages:
   pages:
-    facebook:
+    opengraph:
+      enabled: true
+    insights:
       enabled: false
       appid: '1234567890'
 ```
 
-`enabled` e.g. "Facebook active" enable integration of [Facebook Open Graph](https://developers.facebook.com/docs/opengraph/getting-started) meta-tags.
+`opengraph.enabled` toggles the integration of [Facebook Open Graph](https://ogp.me/) meta-tags.
 
-You need to generate an app_id. Without this property you will lose admin right on the Open Graph Facebook Page.
+`insights.enabled` toggles the integration of [Facebook Insights](https://developers.facebook.com/docs/sharing/referral-insights) meta-tag, which needs an app_id to identify you as the owner of the document. You can find this app_id from the [Facebook App Dashboard](https://developers.facebook.com/apps/redirect/dashboard).
 
 ### Gzip activation
 

--- a/README.md
+++ b/README.md
@@ -137,11 +137,13 @@ social_pages:
 
 `username` e.g. "Twitter Username" is your twitter account reachable by https://twitter/username.
 
-## Associate Facebook App Id
+## Associate Open Graph and Facebook
+
+Open Graph can work without a strong integration to Facebook. This plugin gives you the opportunity to use both and add an app_id to use Facebook Statistics with your website.
 
 ### Namespace configuration
 
-Facebook uses [OpenGraph](http://ogp.me/) metatags. That requires to use a namespace on `html` tag.
+[OpenGraph](http://ogp.me/) requires to use a namespace on the `<html>` tag.
 
 In your base template, add the following line in the `html` tag:
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -114,11 +114,11 @@ form:
                     placeholder: '@'
               facebook:
                 type: tab
-                title: PLUGINS.SOCIAL_SEO_METATAGS.FACEBOOK.NAME
+                title: PLUGINS.SOCIAL_SEO_METATAGS.OPENGRAPH.NAME
                 fields:
-                  social_pages.pages.facebook.enabled:
+                  social_pages.pages.opengraph.enabled:
                     type: toggle
-                    label: PLUGINS.SOCIAL_SEO_METATAGS.FACEBOOK.ENABLED
+                    label: PLUGINS.SOCIAL_SEO_METATAGS.OPENGRAPH.ENABLED
                     highlight: 1
                     default: 0
                     options:
@@ -126,8 +126,18 @@ form:
                       0: PLUGINS.SOCIAL_SEO_METATAGS.NO
                     validate:
                       type: bool
-                  social_pages.pages.facebook.appid:
+                  social_pages.pages.insights.enabled:
+                    type: toggle
+                    label: PLUGINS.SOCIAL_SEO_METATAGS.INSIGHTS.ENABLED
+                    highlight: 1
+                    default: 0
+                    options:
+                      1: PLUGINS.SOCIAL_SEO_METATAGS.YES
+                      0: PLUGINS.SOCIAL_SEO_METATAGS.NO
+                    validate:
+                      type: bool
+                  social_pages.pages.insights.appid:
                     type: text
-                    label: PLUGINS.SOCIAL_SEO_METATAGS.FACEBOOK.APPID
-                    help: PLUGINS.SOCIAL_SEO_METATAGS.FACEBOOK.APPID_HELP
+                    label: PLUGINS.SOCIAL_SEO_METATAGS.INSIGHTS.APPID
+                    help: PLUGINS.SOCIAL_SEO_METATAGS.INSIGHTS.APPID_HELP
                     size: medium

--- a/languages.yaml
+++ b/languages.yaml
@@ -40,10 +40,15 @@ en:
         USERNAME: 'Username'
         USERNAME_HELP: 'If you not use AboutMe plugin, please define your twitter username (@username)'
 
-      FACEBOOK:
+      OPENGRAPH:
         NAME: 'Facebook Open Graph'
-        ENABLED: 'Facebook Open Graph active'
+        ENABLED: 'Facebook Open Graph'
         HELP: 'Share on Facebook'
+
+      INSIGHTS:
+        NAME: 'Facebook Insights'
+        ENABLED: 'Facebook Insights'
+        HELP: 'Analyse on Facebook'
         APPID: 'App ID'
         APPID_HELP: 'The App ID you get from the Facebook Developers page (https://developers.facebook.com/apps).'
 
@@ -87,11 +92,16 @@ fr:
           SUMMARY: 'Carte de résumé'
         ABOUTME: 'Utiliser le plugin AboutMe'
         USERNAME: 'Nom d''utilisateur'
-        USERNAME_HELP: 'Si le plugin AboutMe n''est pas utilisé, veuillez définir le nom d''utilisateur Twitter SVP'
+        USERNAME_HELP: 'Si le plugin AboutMe n’est pas utilisé, veuillez définir le nom d’utilisateur Twitter SVP'
 
-      FACEBOOK:
+      OPENGRAPH:
         NAME: 'Facebook Open Graph'
-        ENABLED: 'Facebook Open Graph activé'
+        ENABLED: 'Facebook Open Graph'
         HELP: 'Partager sur Facebook'
+
+      INSIGHTS:
+        NAME: 'Facebook Insights'
+        ENABLED: 'Facebook Insights'
+        HELP: 'Analyser sur Facebook'
         APPID: 'ID d’application'
         APPID_HELP: 'L’ID d’application pour se connecter à la page Développeurs Facebook (https://developers.facebook.com/apps).'

--- a/social-seo-metatags.php
+++ b/social-seo-metatags.php
@@ -292,9 +292,11 @@ class SocialSEOMetaTagsPlugin extends Plugin
   }
 
   private function getFacebookMetatags($meta){
+    $opengraph_is_active = $this->grav['config']->get('plugins.social-seo-metatags.social_pages.pages.opengraph.enabled');
 
-    if($this->grav['config']->get('plugins.social-seo-metatags.social_pages.pages.facebook.enabled')){
+    $insights_is_active = $this->grav['config']->get('plugins.social-seo-metatags.social_pages.pages.insights.enabled');
 
+    if($opengraph_is_active){
       //Manually convert locale ll by ll_LL from page or default language
       $default_locale = $this->grav["page"]->language();
       if($default_locale == null) $default_locale = $this->grav['config']->get('site.default_lang');
@@ -343,12 +345,14 @@ class SocialSEOMetaTagsPlugin extends Plugin
         }
       }
 
-      if(!isset($meta['fb:app_id'])){
-        $meta['fb:app_id']['property']     = 'fb:app_id';
-        $meta['fb:app_id']['content']      = $this->grav['config']->get('plugins.social-seo-metatags.social_pages.pages.facebook.appid');
+      if ($insights_is_active) {
+          if(!isset($meta['fb:app_id'])){
+            $meta['fb:app_id']['property'] = 'fb:app_id';
+            $meta['fb:app_id']['content']  = $this->grav['config']->get('plugins.social-seo-metatags.social_pages.pages.insights.appid');
+          }
       }
-
     }
+
     return $meta;
   }
 

--- a/social-seo-metatags.yaml
+++ b/social-seo-metatags.yaml
@@ -12,6 +12,8 @@ social_pages:
       enabled: true
       type: summary
       username: ''
-    facebook:
+    opengraph:
+      enabled: true
+    insights:
       enabled: false
       appid: '1234567890'


### PR DESCRIPTION
This PR allows people to use Open Graph without necessarily having to use Facebook Insights:

- Update logic to only include app_id if necessary.
- Update i18n strings (use proper apostrophe in places I updated).
- Remove the sentence that states no template modification is needed (`xmlns` ;) ).
- Update README.

I bumped the Changelog to a major revision number as this breaks previous data structure. Let me know if you know a better way!

I also removed “active” and “activé” as I fell it was making the string longer without providing any missing information. ’Hope you won’t mind. :)