### PR TITLE
Add support for a default image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+# v2.0.2
+## 01/01/2020
+
+1. [](#new)
+    * Add support for a default image.
+
+
 # v2.0.1
 ## 10/21/2019
 

--- a/README.md
+++ b/README.md
@@ -188,13 +188,29 @@ This behavior is discussed [here](https://github.com/getgrav/grav/issues/1955).
 
 ## Other configuration
 
-The plugin allow control on simple quote convertion in html entity. It can be an issue for Twitter sharing.
+### Single quote escaping
 
-There is the configuration
+With the following configuration, the plugin allows the conversion of simple quote (`'`), which can be an issue for Twitter sharing, into html entity (`#039;`):
 
-```
+```yml
 quote:
-  convert_simple: true 
+  convert_simple: true
+```
+
+### Default image
+
+The following defines a default image to use if no image is present in the current Page.
+
+This avoids having to set an image for each Page; useful with repetitive Pages like events or such.
+
+```yml
+default:
+  image:
+    user/assets/images/ZOqdm0x1rzP6iLp.png:
+      name: ZOqdm0x1rzP6iLp.png
+      type: image/png
+      size: 27269
+      path: user/assets/images/ZOqdm0x1rzP6iLp.png
 ```
 
 # Demo

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: Social & SEO Meta Tags
-version: 2.0.1
+version: 2.0.2
 description: Meta-tags for SEO and Social integration (Facebook Open Graph and Twitter Cards)
 icon: code
 author:
@@ -94,6 +94,20 @@ form:
                       0: PLUGINS.SOCIAL_SEO_METATAGS.NO
                     validate:
                       type: bool
+                  # @see https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image
+                  default.image:
+                    type: file
+                    label: PLUGINS.SOCIAL_SEO_METATAGS.GENERAL.DEFAULT.IMAGE.LABEL
+                    help: PLUGINS.SOCIAL_SEO_METATAGS.GENERAL.DEFAULT.IMAGE.HELP
+                    destination: 'user/assets/images'
+                    multiple: false
+                    filesize: 5
+                    random_name: true
+                    accept:
+                      - image/gif
+                      - image/jpeg
+                      - image/png
+                      - image/webp
               twitter:
                 type: tab
                 title: PLUGINS.SOCIAL_SEO_METATAGS.TWITTER.NAME

--- a/languages.yaml
+++ b/languages.yaml
@@ -30,6 +30,10 @@ en:
           SIMPLE_RAW:
             NAME: 'Convert simple quote to html entity (using code #039;)'
             HELP: 'For Twitter sharing, raw simple quote may be necessary.'
+        DEFAULT:
+          IMAGE:
+            LABEL: 'Default image'
+            HELP: 'This image will be used if no other image is available in the Page.'
 
       TWITTER:
         NAME: 'Twitter Cards'
@@ -86,6 +90,10 @@ fr:
           SIMPLE_RAW:
             NAME: 'Convertir les guillemets simples en entité HTML (utilisant code #039;)'
             HELP: 'Pour les partages Twitter, utiliser les guillemets simple brut est nécessaire.'
+        DEFAULT:
+          IMAGE:
+            LABEL: 'Image par défaut'
+            HELP: 'Cette image sera utilisée si aucune autre image n’existe dans la Page.'
 
       TWITTER:
         NAME: 'Cartes Twitter'

--- a/social-seo-metatags.php
+++ b/social-seo-metatags.php
@@ -414,7 +414,7 @@ class SocialSEOMetaTagsPlugin extends Plugin
         '/\:\"(.*?)\"\:/'                        => '\1',  // quote
         '/```(.*)\n((.*|\n)+)\n```/'             => '\2',  // fence code
         '/`(.*?)`/'                              => '\1',  // inline code
-        '/(\*|\+|-)(.*)/'                        => '\2',  // ul lists
+        '/\n(\*|\+|-)(.*)/'                      => '\2',  // ul lists
         '/\n[0-9]+\.(.*)/'                       => '\2',  // ol lists
         '/(&gt;|\>)+(.*)/'                       => '\2',  // blockquotes
     );

--- a/social-seo-metatags.php
+++ b/social-seo-metatags.php
@@ -1,9 +1,10 @@
 <?php
 namespace Grav\Plugin;
 
-use Grav\Common\Page\Page;
 use Grav\Common\Page\Medium\MediumFactory;
+use Grav\Common\Page\Page;
 use Grav\Common\Plugin;
+use Grav\Common\Utils;
 use RocketTheme\Toolbox\Event\Event;
 
 /**
@@ -311,7 +312,11 @@ class SocialSEOMetaTagsPlugin extends Plugin
         if (isset($image)) {
           $meta['twitter:image']['name']     = 'twitter:image';
           $meta['twitter:image']['property'] = 'twitter:image';
-          $meta['twitter:image']['content']  = $this->grav['uri']->base() . $image->url();
+          $meta['twitter:image']['content']  = str_replace(
+            ' ',
+            '%20',
+            Utils::url($image->url(), true)
+          );
         }
       }
 
@@ -376,8 +381,12 @@ class SocialSEOMetaTagsPlugin extends Plugin
         $image = $this->getFirstImage() ?: $this->getDefaultImage();
 
         if(isset($image)) {
-          $meta['og:image']['property']  = 'og:image';
-          $meta['og:image']['content']   = $this->grav['uri']->base() . $image->url();
+          $meta['og:image']['property'] = 'og:image';
+          $meta['og:image']['content']  = str_replace(
+            ' ',
+            '%20',
+            Utils::url($image->url(), true)
+          );
         }
       }
 


### PR DESCRIPTION
I think the title and the README are quite explanatory, so I’ll just copy and paste here:

> The following defines a default image to use if no image is present in the current Page.
> 
> This avoids having to set an image for each Page; useful with repetitive Pages like events or such.

I also took the liberty to rewrite a bit the `getFirstImage` function as I felt it could be more straightforward; let me know if I should not have. :)