### PR TITLE
Check if image is set and of correct type

### DIFF
--- a/social-seo-metatags.php
+++ b/social-seo-metatags.php
@@ -323,7 +323,9 @@ class SocialSEOMetaTagsPlugin extends Plugin
       $image = isset($images) ? array_shift($images) : null;
     }
 
-    return $this->getImage($image);
+    return isset($image) && $image instanceof ImageMedium
+        ? $this->getImage($image) 
+        : null;
   }
 
   /**
@@ -359,7 +361,9 @@ class SocialSEOMetaTagsPlugin extends Plugin
       $image = MediumFactory::fromFile($path);
     }
 
-    return $this->getImage($image);
+    return isset($image) && $image instanceof ImageMedium
+        ? $this->getImage($image)
+        : null;
   }
 
   private function getTwitterCardMetatags($meta)


### PR DESCRIPTION
Functions that use getImage might not have an image set when calling the
function.
Make sure that the image is set and of type ImageMedium before calling
getImage or return null.

This bug got introduced with https://github.com/clemdesign/grav-plugin-social-seo-metatags/commit/b9289620b2151a8053f7c918e3b778ec27bd878f?diff=split#diff-09e405b8d73a2d346db79380d13facaadb7338aa25066cce734538d4f597ea96L303

Fix #26 